### PR TITLE
Simplify script

### DIFF
--- a/genuserlist.sh
+++ b/genuserlist.sh
@@ -1,6 +1,4 @@
 #!/bin/bash
 
 # This removes /etc/pgbouncer/userlist.txt and replaces it with a valid configured file.
-rm /etc/pgbouncer/userlist.txt 
-psql -Upostgres -c"select usename,passwd from pg_shadow order by 1" | sed 's/|//' | grep -v "+\|rows\|passwd" | awk 'NF > 0' | awk '{print "\""$1"\"","\""$2"\""}' >> /etc/pgbouncer/userlist.txt
-chown pgbouncer: /etc/pgbouncer/userlist.txt
+psql -Atq -U postgres -d postgres -c "SELECT concat('\"', usename, '\" \"', passwd, '\"') FROM pg_shadow" > /etc/pgbouncer/userlist.txt


### PR DESCRIPTION
- No need to rm and chown if you `>` the output
- The owner of the file was `postgresql:postgresql` for me anyway
- Simpler command, no shell pipes